### PR TITLE
Client timeout.

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ See [PROTOCOL.md](PROTOCOL.md).
 
 # Future Plans (soon)
 
-- [ ] Client Timeout
+- [x] ~~Client Timeout~~ (done in v0.1.1)
 - [ ] Middlewares
 - [ ] Tests
 - [ ] Release on PyPi

--- a/shisetsu/exceptions.py
+++ b/shisetsu/exceptions.py
@@ -13,3 +13,13 @@ class RequestFailure(Exception):
     def __init__(self, failure):
         self.message = failure.get()['failure_message']
         super(RequestFailure, self).__init__(self.message)
+
+
+class TimeoutError(Exception):
+    """Raised when timeout has been reached after calling a remote function.
+    """
+
+    def __init__(self, func, timeout):
+        self.message = 'No response from remote func `{}` after {} seconds'\
+                       .format(func, timeout)
+        super(TimeoutError, self).__init__(self.message)


### PR DESCRIPTION
Simple client timeout mechanism. When instantiating a Client, a new `timeout` parameter may be passed. It will raise a `TimeoutError` after `timeout` seconds if no response is received through the receiving channel. If `timeout` set to `None`, a `call()` operation will block indefinitely:

```python
>>> from shisetsu.client import client   # but don't start a server
>>> c = Client('test', timeout=5)
>>> c.call('function')
TimeoutError: No response from remote func `function` after 5 seconds
```

`timeout` can also be re-set using `Client.set_timeout`:

```python
>>> c.set_timeout(1)
>>> c.call('function')
TimeoutError: No response from remote func `function` after 1 seconds
```