### PR TITLE
Middlewares support, PyPI.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *.pyc
 .virtualenv
+build/

--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@ This is the Python implementation of Shisetsu. Both this implementation and the 
 # Quick Start
 
 1. Install Redis and start the Redis server
-2. Clone Shisetsu, install requirements with `pip install -r requirements.txt`
-3. Open up a Python terminal
+2. `$ pip install shisetsu` or clone this repo and run `$ python setup.py install`
+3. Open up Python
 
 To start a Shisetsu Server:
 ```python
@@ -42,9 +42,9 @@ See [PROTOCOL.md](PROTOCOL.md).
 # Future Plans (soon)
 
 - [x] ~~Client Timeout~~ (done in v0.1.1)
-- [ ] Middlewares
+- [x] ~~Middlewares~~ (done in v0.1.2)
 - [ ] Tests
-- [ ] Release on PyPi
+- [x] ~~Release on PyPi~~ (done in v0.1.2)
 - [ ] Authorization/authentication support
 - [ ] Async (Python 3 `async`/`await`?)
 - [ ] [Request more](https://github.com/KixPanganiban/shisetsu/issues/)

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,25 @@
+"""Setup script for Shisetsu
+"""
+
+from distutils.core import setup
+
+from pip.req import parse_requirements
+from pip.download import PipSession
+
+VERSION = '0.1.2'
+
+REQUIREMENTS = [str(req) for req in parse_requirements(
+    'requirements.txt',
+    session=PipSession())]
+
+setup(
+    name='Shisetsu',
+    version=VERSION,
+    description='An RPC-like protocol on top of Redis',
+    author='Kix Panganiban',
+    author_email='kixpanganiban@protonmail.com',
+    url='https://github.com/KixPanganiban/Shisetsu',
+    packages=['shisetsu'],
+    install_requires=REQUIREMENTS,
+    license='MIT',
+    )

--- a/shisetsu/exceptions.py
+++ b/shisetsu/exceptions.py
@@ -1,10 +1,15 @@
 """
-shisetsu.contract
+shisetsu.exceptions
 <github.com/kixpanganiban>
 
 Contains `DigestMismatch`.
 """
 
+
+class MiddlewareError(Exception):
+    """Raised when a middleware doesn't return a contract.
+    """
+    pass
 
 class RequestFailure(Exception):
     """Raised when a Contract was not fulfilled.

--- a/shisetsu/middlewares.py
+++ b/shisetsu/middlewares.py
@@ -1,0 +1,84 @@
+"""
+shisetsu.middlewares
+<github.com/kixpanganiban>
+
+Contains `Middlewares`.
+"""
+from .contract import Contract
+from .exceptions import MiddlewareError
+
+class Middlewares(object):
+    """Middlewares facilitate registering and executing middlwares wherever
+    they are defined. To add a middleware handler, a function called `handler`
+    may be passed to `Middlewares.register_before` or
+    `Middlewares.register_after`.
+
+    In a Server:
+    All handlers registered via the former are called before the contract is
+    sent to the `func` it calls, that is, after it is unpacked and created.
+    Handlers registered via the latter are called after the `func` returns a
+    response and an outgoing contract is created.
+
+    In a Client:
+    All handlers registered via the former are called before the request is
+    packed and sent to the channel. Handlers registered via the latter are
+    called after the response is received, and before the response body is
+    returned.
+
+    A `handler` MUST return a Contract after execution, or a `MiddlewareError`
+    will be raised. To interrupt processing of a contract, you may raise a
+    custom exception inside a handler.
+
+    Example usage:
+        from shisetsu.server import Server
+
+        def dictify(contract):
+            contract.body = {
+                'status': 'OK',
+                'content': contract.body
+            }
+            return contract
+
+        s = Server('db_reader')
+        server.middlewares.register_after(dictify)
+    """
+
+    def __init__(self):
+        self._middlewares = {
+            'before': [],
+            'after': []
+        }
+
+    @classmethod
+    def check_return(cls, return_value):
+        """Check if the middleware handler's response is a valid Contract.
+        """
+        if not return_value:
+            raise MiddlewareError('Middleware handler returned None')
+        if not isinstance(return_value, Contract):
+            raise MiddlewareError('Middleware must return a contract')
+        return return_value
+
+    def register_before(self, handler):
+        """Register a before `handler`.
+        """
+        self._middlewares['before'].append(handler)
+
+    def register_after(self, handler):
+        """Register an after `handler`.
+        """
+        self._middlewares['after'].append(handler)
+
+    def execute_before(self, contract):
+        """Execute all before `handler`s on the contract.
+        """
+        for handler in self._middlewares['before']:
+            contract = self.check_return(handler(contract))
+        return contract
+
+    def execute_after(self, contract):
+        """Execute all after `handler`s on the contract.
+        """
+        for handler in self._middlewares['after']:
+            contract = self.check_return(handler(contract))
+        return contract


### PR DESCRIPTION
Quick update right after I released `v0.1.1`: **middlewares support** and **release on PyPI**!

I added a simple middleware mechanism that should support basic middleware requirements. For more details, see the docstring of the `Middlewares` class here: [middlewares.py](https://github.com/KixPanganiban/shisetsu/blob/master/shisetsu/middlewares.py). Middlewares are supported both Server- and Client-side, and would let you do some stuff such as pack a function's response into a dict before returning it to the client.

This also releases Shisetsu into the wild via PyPI, and would let you install with just `pip install shisetsu`.